### PR TITLE
[Fix] 폰트와 code highlight에서 발생하던 문제 긴급(..) 수정

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,6 +7,9 @@ import Seo from "../components/seo";
 
 import PostListItem from "../components/main/PostListItem";
 
+import { defineCustomElements as deckDeckGoHighlightElement } from "@deckdeckgo/highlight-code/dist/loader";
+deckDeckGoHighlightElement();
+
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`;
   const posts = data.allMarkdownRemark.nodes;

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -9,9 +9,6 @@ import Seo from "../components/seo";
 import Comments from "../components/Comments";
 import { BlogPostContainer, BlogPostContent } from "./blog-post.styles";
 
-import { defineCustomElements as deckDeckGoHighlightElement } from "@deckdeckgo/highlight-code/dist/loader";
-deckDeckGoHighlightElement();
-
 const BlogPostTemplate = ({
   data: { previous, next, site, markdownRemark: post },
   location,

--- a/static/fonts/EliceDigitalCoding/EliceDigitalCoding.css
+++ b/static/fonts/EliceDigitalCoding/EliceDigitalCoding.css
@@ -2,13 +2,13 @@
   font-family: "Elice Digital Coding";
   font-style: normal;
   font-weight: 400;
-  src: url("EliceDigitalCodingOTF_Regular.otf") format("opentype"),
+  src: url("EliceDigitalCodingOTF_Regular.otf") format("otf"),
     url("EliceDigitalCodingverH_Regular.ttf") format("truetype");
 }
 @font-face {
   font-family: "Elice Digital Coding";
   font-style: normal;
   font-weight: 700;
-  src: url("EliceDigitalCodingOTF_Bold.otf") format("opentype"),
+  src: url("EliceDigitalCodingOTF_Bold.otf") format("otf"),
     url("EliceDigitalCodingverH_Bold.ttf") format("truetype");
 }


### PR DESCRIPTION
1. failed to decode downloaded font 이러한 Warning 발생으로 폰트 포맷을 수정해줌 (근데 어떻게 해결된 건진 아직 모르겠다...)
2. 간혹 gatsby-remark-highlight-code 안에 코드 내용이 잘 들어가지 않는 문제가 있었고, 매뉴얼을 다시 읽어보니 (https://github.com/deckgo/gatsby-remark-highlight-code#load-the-component) deckDeckGoHighlightElement() 함수를 블로그의 "메인 파일" 에서 불러와야 한다는 내용이 있어서 기존 blog-post 템플릿 파일에서 index.js 파일로 옮겨줌 (RTFM...)